### PR TITLE
Fix tilemap and clipdata for Chozodia 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 
 include/**/*.s
 tools/*.txt
+tools/c_extractor
 .vscode

--- a/database.txt
+++ b/database.txt
@@ -2389,7 +2389,8 @@ rooms/chozodia/Chozodia_10_Clipdata.gfx;122;0x72fd4a;1
 rooms/chozodia/Chozodia_10_Bg2.gfx;178;0x72fdc4;1
 rooms/chozodia/Chozodia_10_Bg1.gfx;465;0x72fe76;1
 
-rooms/chozodia/Chozodia_11_Clipdata.gfx;109;0x73005a;1
+rooms/chozodia/Chozodia_11_Clipdata.gfx;95;0x73005a;1
+rooms/chozodia/Chozodia_11_Bg2_Unused.gfx;14;0x7300b9;1
 rooms/chozodia/Chozodia_11_Bg1.gfx;221;0x7300c7;1
 
 rooms/chozodia/Chozodia_12_Clipdata.gfx;276;0x7301be;1

--- a/include/data/rooms/chozodia_rooms_data.h
+++ b/include/data/rooms/chozodia_rooms_data.h
@@ -79,7 +79,8 @@ extern const u8 sChozodia_10_Bg1[465];
 extern const u8 sChozodia_10_Spriteset0[ENEMY_ROOM_DATA_ARRAY_SIZE(3)];
 
 extern const u8 sChozodia_7_Scrolls[SCROLL_DATA_SIZE(1)];
-extern const u8 sChozodia_11_Clipdata[109];
+extern const u8 sChozodia_11_Clipdata[95];
+extern const u8 sChozodia_11_Bg2_Unused[14];
 extern const u8 sChozodia_11_Bg1[221];
 extern const u8 sChozodia_11_Spriteset0[ENEMY_ROOM_DATA_ARRAY_SIZE(2)];
 

--- a/src/data/rooms/chozodia/Chozodia_11.c
+++ b/src/data/rooms/chozodia/Chozodia_11.c
@@ -13,7 +13,9 @@ const u8 sChozodia_7_Scrolls[SCROLL_DATA_SIZE(1)] = {
 	UCHAR_MAX, // Breakeable block Y bound extension
 };
 
-const u8 sChozodia_11_Clipdata[109] = INCBIN_U8("data/rooms/chozodia/Chozodia_11_Clipdata.gfx");
+const u8 sChozodia_11_Clipdata[95] = INCBIN_U8("data/rooms/chozodia/Chozodia_11_Clipdata.gfx");
+
+const u8 sChozodia_11_Bg2_Unused[14] = INCBIN_U8("data/rooms/chozodia/Chozodia_11_Bg2_Unused.gfx");
 
 const u8 sChozodia_11_Bg1[221] = INCBIN_U8("data/rooms/chozodia/Chozodia_11_Bg1.gfx");
 

--- a/src/data/rooms_data.c
+++ b/src/data/rooms_data.c
@@ -658,7 +658,7 @@ const struct TilesetEntry sTilesetEntries[79] = {
 		.pTileGraphics = sTileset_78_Gfx,
 		.pPalette = sTileset_42_Pal,
 		.pBackgroundGraphics = sTileset_42_Bg_Gfx,
-		.pTilemap = (const u8*)0x85e0d24,
+		.pTilemap = sTileset_78_Tilemap,
 		.animatedTileset = 0,
 		.animatedPalette = 16
 	}


### PR DESCRIPTION
- Tileset 78 had a hard coded tilemap pointer
- Chozodia 11's clipdata included unused bg2 data
- Also added c_extractor to .gitignore

- [x] I have read and understood the conditions outlined in [CONTRIBUTING.md](CONTRIBUTING.md)
