### PR TITLE
Minor fixes

### DIFF
--- a/include/audio_wrappers.h
+++ b/include/audio_wrappers.h
@@ -3,6 +3,10 @@
 
 #include "structs/audio.h"
 
+extern void call_soundcode_a(void);
+extern void call_soundcode_b(void);
+extern void call_soundcode_c(void);
+
 void InitializeAudio(void);
 void DoSoundAction(u32 action);
 void SetupSoundTransfer(void);

--- a/include/bg_clip.h
+++ b/include/bg_clip.h
@@ -11,7 +11,7 @@ void BgClipSetRawBG1BlockValue(u32 value, u16 yPosition, u16 xPosition);
 void BgClipSetClipdataBlockValue(u16 value, u16 yPosition, u16 xPosition);
 void BgClipCheckTouchingSpecialClipdata(void);
 void BgClipApplyClipdataChangingTransparency(void);
-u16 BgClipGetNewBldalphaValue(u16 clip, u16);
+u16 BgClipGetNewBldalphaValue(u16 clip, u16 unused);
 void BgClipCheckWalkingOnCrumbleBlock(void);
 void BgClipCheckTouchingTransitionOnElevator(void);
 void BgClipCheckTouchingTransitionOrTank(void);

--- a/include/constants/event.h
+++ b/include/constants/event.h
@@ -85,7 +85,7 @@ enum Event {
     EVENT_COUNT
 };
 
-enum {
+enum EventAction {
     EVENT_ACTION_CLEARING,
     EVENT_ACTION_SETTING,
     EVENT_ACTION_TOGGLING,

--- a/include/data/tourian_escape_data.h
+++ b/include/data/tourian_escape_data.h
@@ -64,7 +64,7 @@ extern const u16 sTourianEscape_47a6ba[OAM_DATA_SIZE(1)];
 
 extern const u16 sTourianEscape_47a6c2[OAM_DATA_SIZE(4)];
 extern const u16 sTourianEscape_47a6dc[OAM_DATA_SIZE(4)];
-extern const u16 sTourianEscape_47a6f8[OAM_DATA_SIZE(4)];
+extern const u16 sTourianEscape_47a6f6[OAM_DATA_SIZE(4)];
 extern const u16 sTourianEscape_47a710[OAM_DATA_SIZE(4)];
 extern const u16 sTourianEscape_47a72a[OAM_DATA_SIZE(4)];
 extern const u16 sTourianEscape_47a744[OAM_DATA_SIZE(4)];

--- a/src/audio_wrappers.c
+++ b/src/audio_wrappers.c
@@ -4,10 +4,6 @@
 #include "gba.h"
 #include "macros.h"
 
-extern void call_soundcode_a(void);
-extern void call_soundcode_b(void);
-extern void call_soundcode_c(void);
-
 /**
  * @brief 2564 | 294 | Initializes the audio
  * 

--- a/src/data/sprites/zebetite_and_cannon.c
+++ b/src/data/sprites/zebetite_and_cannon.c
@@ -420,7 +420,7 @@ const u16 sCannonOam_ShootingDownRight_Frame2[OAM_DATA_SIZE(2)] = {
     0x3, OBJ_X_FLIP | 0x3, OBJ_SPRITE_OAM | 0x248
 };
 
-const u16 sCannonOam_RightToRightTransition_Frame0[OAM_DATA_SIZE(2)] = {
+const u16 sCannonOam_DownRightToRightTransition_Frame0[OAM_DATA_SIZE(2)] = {
     0x2,
     0xf8, OBJ_SIZE_16x16 | 0x1f8, OBJ_SPRITE_OAM | 0x21c,
     OBJ_SHAPE_HORIZONTAL | 0x1, OBJ_X_FLIP | 0x0, OBJ_SPRITE_OAM | 0x267
@@ -837,7 +837,7 @@ const struct FrameData sCannonOam_ShootingDownRight[4] = {
 
 const struct FrameData sCannonOam_DownRightToRightTransition[2] = {
     [0] = {
-        .pFrame = sCannonOam_RightToRightTransition_Frame0,
+        .pFrame = sCannonOam_DownRightToRightTransition_Frame0,
         .timer = CONVERT_SECONDS(0.05f)
     },
     [1] = FRAME_DATA_TERMINATOR

--- a/src/dma.c
+++ b/src/dma.c
@@ -46,8 +46,8 @@ void DmaTransfer(u8 channel, void *src, void *dst, u32 len, u8 bitSize)
         CHECK_DMA_ENDED(channel);
 
         len -= 0x800;
-        (char*)src += 0x800;
-        (char*)dst += 0x800;
+        src += 0x800;
+        dst += 0x800;
     }
 
     pDma->pSrc = src;

--- a/src/menus/pause_screen.c
+++ b/src/menus/pause_screen.c
@@ -501,8 +501,10 @@ u8 PauseScreenStatusScreenShouldDrawHeader(u8 samusWireframeDataIndex)
             case SAMUS_WIREFRAME_DATA_BEAM:
             case SAMUS_WIREFRAME_DATA_SUIT:
                 result = TRUE << 1;
+                break;
 
             case SAMUS_WIREFRAME_DATA_SAMUS_POWER_SUIT_WIREFRAME:
+                break;
         }
     }
 

--- a/src/sprites_AI/space_pirate.c
+++ b/src/sprites_AI/space_pirate.c
@@ -807,6 +807,7 @@ void SpacePirateSamusDetection(void)
         case SPACE_PIRATE_POSE_JUMPING_INIT:
         case SPACE_PIRATE_POSE_JUMPING:
         case SPACE_PIRATE_POSE_WALL_JUMPING:
+            break;
     }
     
     gSpriteDrawOrder[2] = FALSE;

--- a/src/text.c
+++ b/src/text.c
@@ -1184,6 +1184,7 @@ void TextProcessDescription(void)
             break;
 
         case 6:
+            break;
     }
 }
 


### PR DESCRIPTION
Some minor fixes, mostly related to stuff I've found while trying to auto-extract info for the maps website:
- Fixed line endings in check_roms.sh
- Fixed enum without a name (EventAction)
- Fixed declaration names that didn't match definition name
- Added missing break statements