### PR TITLE
BUGFIX: Mother Brain block not spawning when there are too many sprites

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -41,18 +41,18 @@ Whenever there are too many (24) active sprites in the Mother Brain room, the bl
 
 ```c
 #ifdef BUGFIX
-        u8 blockSlot = SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
-            gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
-        if (blockSlot != UCHAR_MAX)
-        {
-            gCurrentSprite.pose = MOTHER_BRAIN_PART_POSE_GLASS_STAGE_1;
-            gCurrentSprite.status &= ~SPRITE_STATUS_IGNORE_PROJECTILES;
-        }
+u8 blockSlot = SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
+    gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
+if (blockSlot != UCHAR_MAX)
+{
+    gCurrentSprite.pose = MOTHER_BRAIN_PART_POSE_GLASS_STAGE_1;
+    gCurrentSprite.status &= ~SPRITE_STATUS_IGNORE_PROJECTILES;
+}
 #else // !BUGFIX
-        SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
-            gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
-        gCurrentSprite.pose = MOTHER_BRAIN_PART_POSE_GLASS_STAGE_1;
-        gCurrentSprite.status &= ~SPRITE_STATUS_IGNORE_PROJECTILES;
+SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
+    gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
+gCurrentSprite.pose = MOTHER_BRAIN_PART_POSE_GLASS_STAGE_1;
+gCurrentSprite.status &= ~SPRITE_STATUS_IGNORE_PROJECTILES;
 #endif // BUGFIX
 ```
 

--- a/src/sprites_AI/mother_brain.c
+++ b/src/sprites_AI/mother_brain.c
@@ -622,10 +622,20 @@ static void MotherBrainSpawnBlock(void)
 
     if (gSamusData.xPosition < xPosition - (BLOCK_SIZE - PIXEL_SIZE))
     {
-        SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL, gCurrentSprite.primarySpriteRamSlot,
-            yPosition, xPosition, 0);
+#ifdef BUGFIX
+        u8 blockSlot = SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
+            gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
+        if (blockSlot != UCHAR_MAX)
+        {
+            gCurrentSprite.pose = MOTHER_BRAIN_PART_POSE_GLASS_STAGE_1;
+            gCurrentSprite.status &= ~SPRITE_STATUS_IGNORE_PROJECTILES;
+        }
+#else // !BUGFIX
+        SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
+            gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
         gCurrentSprite.pose = MOTHER_BRAIN_PART_POSE_GLASS_STAGE_1;
         gCurrentSprite.status &= ~SPRITE_STATUS_IGNORE_PROJECTILES;
+#endif // BUGFIX
     }
 }
 

--- a/src/sprites_AI/mother_brain.c
+++ b/src/sprites_AI/mother_brain.c
@@ -622,7 +622,7 @@ static void MotherBrainSpawnBlock(void)
 
     if (gSamusData.xPosition < xPosition - (BLOCK_SIZE - PIXEL_SIZE))
     {
-#ifdef BUGFIX
+        #ifdef BUGFIX
         u8 blockSlot = SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
             gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
         if (blockSlot != UCHAR_MAX)
@@ -630,12 +630,12 @@ static void MotherBrainSpawnBlock(void)
             gCurrentSprite.pose = MOTHER_BRAIN_PART_POSE_GLASS_STAGE_1;
             gCurrentSprite.status &= ~SPRITE_STATUS_IGNORE_PROJECTILES;
         }
-#else // !BUGFIX
+        #else // !BUGFIX
         SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
             gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
         gCurrentSprite.pose = MOTHER_BRAIN_PART_POSE_GLASS_STAGE_1;
         gCurrentSprite.status &= ~SPRITE_STATUS_IGNORE_PROJECTILES;
-#endif // BUGFIX
+        #endif // BUGFIX
     }
 }
 


### PR DESCRIPTION
The implemented fix for this is quite simple, even simpler than the suggested as "potential fix": Do not progress Mother Brain's pose until the block successfully spawns.

I tested it in-game and it seems to me that it works fine.

In the documentation, I have added a small explanation of the bug, and the fix. I have formatted the fix to be similar to the others in the file (i.e., using a C-syntax code snippet, that is just a copy-paste of the affected code). However, shouldn't we consider using diff syntax instead, like they do in pret's pokeemerald? It would look like this:
```diff
- SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
-      gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
+ u8 blockSlot = SpriteSpawnSecondary(SSPRITE_MOTHER_BRAIN_BLOCK, 0, SPRITE_GFX_SLOT_SPECIAL,
+      gCurrentSprite.primarySpriteRamSlot, yPosition, xPosition, 0);
+ if (blockSlot != UCHAR_MAX)
+ {
      gCurrentSprite.pose = MOTHER_BRAIN_PART_POSE_GLASS_STAGE_1;
      gCurrentSprite.status &= ~SPRITE_STATUS_IGNORE_PROJECTILES;
+ }
```