### PR TITLE
Automatically build tools required to compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 linker.ld.pp
 include/**/*.s
 tools/*.txt
+tools/agbcc
 .vscode
 
 err.log

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ endif
 BASEROM := $(TARGET)_baserom.gba
 TARGET := $(TARGET).gba
 
+# Default target
+.PHONY: all
+all: $(TARGET)
+
 ELF = $(TARGET:.gba=.elf)
 MAP = $(TARGET:.gba=.map)
 SHA1FILE = $(TARGET:.gba=.sha1)
@@ -91,10 +95,11 @@ SHA1SUM = sha1sum
 TAIL = tail
 
 # Tools
-GBAFIX = tools/gbafix/gbafix
+include make_tools.mk
+GBAFIX = $(TOOLS_DIR)/gbafix/gbafix
 PYTHON = python3
-EXTRACTOR = tools/extractor.py
-PREPROC = tools/preproc/preproc
+EXTRACTOR = $(PYTHON) $(TOOLS_DIR)/extractor.py
+PREPROC = $(TOOLS_DIR)/preproc/preproc
 
 # Flags
 ASFLAGS += -mcpu=arm7tdmi
@@ -125,8 +130,25 @@ else
 	MSG = @echo " "
 endif
 
-.PHONY: all
-all: $(TARGET)
+# Rules that do not require scanning for dependencies
+RULES_NO_SCAN += dump diff extract clean tidy
+
+# Generate tools before building anything
+SETUP_PREREQS ?= 1
+# Disable generating tools for rules that do not build anything
+ifneq (,$(MAKECMDGOALS))
+  ifeq (,$(filter-out $(RULES_NO_SCAN),$(MAKECMDGOALS)))
+    SETUP_PREREQS := 0
+  endif
+endif
+.SHELLSTATUS ?= 0
+ifeq ($(SETUP_PREREQS),1)
+  $(foreach line, $(shell $(MAKE) -f make_tools.mk | sed "s/ /__SPACE__/g"), $(info $(subst __SPACE__, ,$(line))))
+  ifneq ($(.SHELLSTATUS),0)
+    $(error Errors occurred while building tools. See error messages above for more details)
+  endif
+endif
+
 
 .PHONY: check
 check: all
@@ -144,10 +166,13 @@ diff: $(DUMPS)
 .PHONY: extract
 extract:
 	$(MSG) Extracting
-	$Q python3 tools/extractor.py -r $(REGION)
+	$Q$(EXTRACTOR) -r $(REGION)
 
 .PHONY: clean
-clean:
+clean: clean-tools tidy
+
+.PHONY: tidy
+tidy:
 	$(MSG) RM roms
 # Delete every gba file that doesn't end with baserom
 	$Qfind -type f -name "*.gba" -a ! -name "*baserom.gba" -delete
@@ -190,7 +215,7 @@ help:
 	@echo '  REGION=<region>: selects the region of the ROM, possible values are "us", "eu", "jp", "cn", "us_beta", and "eu_beta"'
 	@echo '  DEBUG=1: enables the debug code'
 
-$(TARGET): $(ELF) $(GBAFIX)
+$(TARGET): $(ELF)
 	$(MSG) OBJCOPY $@
 	$Q$(OBJCOPY) -O binary --gap-fill 0xff --pad-to $(PAD_TO) $< $@
 	$(MSG) GBAFIX $@
@@ -221,10 +246,6 @@ src/dma.s: src/dma.c
 
 src/sram/%.s: CFLAGS = -Werror -O1 -mthumb-interwork -fhex-asm -f2003-patch
 src/sram/%.s: src/sram/%.c
-
-tools/%: tools/%.c
-	$(MSG) HOSTCC $@
-	$Q$(HOSTCC) $< $(HOSTCFLAGS) $(HOSTCPPFLAGS) -o $@
 
 .PHONY: us us_debug us_beta eu eu_debug eu_beta jp jp_debug
 # cn cn_debug

--- a/Makefile
+++ b/Makefile
@@ -113,10 +113,17 @@ CSRC = $(wildcard src/**.c) $(wildcard src/**/**.c) $(wildcard src/**/**/**.c) $
 ASMSRC = $(CSRC:.c=.s) $(wildcard asm/*.s) $(wildcard sound/*.s) $(wildcard sound/**/*.s) $(wildcard sound/**/**/*.s)
 OBJ = $(ASMSRC:.s=.o) 
 
-# Dynamically find agbcc path and its lib folder
-AGBCC_BIN := $(shell which agbcc)
-AGBCC_DIR := $(dir $(AGBCC_BIN))/
-AGBCC_LIB := $(abspath $(AGBCC_DIR))
+# Detect if agbcc was installed into the project
+ifneq (,$(wildcard tools/agbcc))
+	AGBCC_BIN := tools/agbcc/bin/agbcc
+	AGBCC_LIB := tools/agbcc/lib
+	CC = $(AGBCC_BIN)
+else
+	# Dynamically find agbcc path and its lib folder
+	AGBCC_BIN := $(shell which agbcc)
+	AGBCC_DIR := $(dir $(AGBCC_BIN))/
+	AGBCC_LIB := $(abspath $(AGBCC_DIR))
+endif
 
 LIBS := $(AGBCC_LIB)/libgcc.a $(AGBCC_LIB)/libc.a
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ The default built ROM is mzm_us.gba
 - Install `make` by running this command: `sudo apt-get install make`
 - Clone [agbcc](https://github.com/jiangzhengwenjz/agbcc) by running this command: `git clone https://github.com/jiangzhengwenjz/agbcc`
 - Enter the agbcc folder (run `cd agbcc`) and build it (run `./build.sh`)
-- Add agbcc to your path (`export PATH="<agbcc_path>:$PATH"`, where `<agbcc_path>` is the full path to the agbcc directory)
-- Locate yourself in the decompilation root, and then build preproc (run `cd tools/preproc && make`)
+- Either:
+  - Install agbcc into this project (by using its `./install.sh <path>` script, where `<path>` is the path to the root of this repository), or
+  - Add agbcc to your path (`export PATH="<agbcc_path>:$PATH"`, where `<agbcc_path>` is the full path to the agbcc directory)
 
 ## Build
 

--- a/make_tools.mk
+++ b/make_tools.mk
@@ -1,0 +1,26 @@
+# Make rules to build the tools used for compilation, inside `tools` folder.
+ifeq ($(V),1)
+	Q =
+	MSG = @:
+else
+	Q = @
+	MSG = @echo " "
+endif
+
+MAKEFLAGS += --no-print-directory
+
+TOOLS_DIR := tools
+# Tool executables tu build
+TOOLS := gbafix preproc
+
+TOOLDIRS := $(TOOLS:%=$(TOOLS_DIR)/%)
+
+.PHONY: tools clean-tools $(TOOLDIRS)
+
+tools: $(TOOLDIRS)
+
+$(TOOLDIRS):
+	$Q$(MAKE) -C $@
+
+clean-tools:
+	$Q$(foreach tooldir, $(TOOLDIRS), $(MAKE) clean -C $(tooldir);)

--- a/make_tools.mk
+++ b/make_tools.mk
@@ -10,7 +10,7 @@ endif
 MAKEFLAGS += --no-print-directory
 
 TOOLS_DIR := tools
-# Tool executables tu build
+# Tool executables to build
 TOOLS := gbafix preproc
 
 TOOLDIRS := $(TOOLS:%=$(TOOLS_DIR)/%)

--- a/tools/gbafix/Makefile
+++ b/tools/gbafix/Makefile
@@ -1,0 +1,30 @@
+CC ?= gcc
+RM ?= rm -f
+ifeq ($(V),1)
+	Q =
+	MSG = @:
+else
+	Q = @
+	MSG = @echo " "
+endif
+
+.PHONY: all clean
+
+SRCS = gbafix.c
+
+ifeq ($(OS),Windows_NT)
+EXE := .exe
+else
+EXE :=
+endif
+
+all: gbafix$(EXE)
+	@:
+
+gbafix$(EXE): $(SRCS)
+	$(MSG) CC $@
+	$Q$(CC) $(SRCS) -o $@ $(LDFLAGS)
+
+clean:
+	$(MSG) RM gbafix$(EXE)
+	$Q$(RM) gbafix gbafix.exe

--- a/tools/preproc/Makefile
+++ b/tools/preproc/Makefile
@@ -1,4 +1,12 @@
 CXX ?= g++
+RM ?= rm -f
+ifeq ($(V),1)
+	Q =
+	MSG = @:
+else
+	Q = @
+	MSG = @echo " "
+endif
 
 CXXFLAGS := -std=c++11 -O2 -Wall -Wno-switch -Werror
 
@@ -20,7 +28,9 @@ all: preproc$(EXE)
 	@:
 
 preproc$(EXE): $(SRCS) $(HEADERS)
-	$(CXX) $(CXXFLAGS) $(SRCS) -o $@ $(LDFLAGS)
+	$(MSG) CXX $@
+	$Q$(CXX) $(CXXFLAGS) $(SRCS) -o $@ $(LDFLAGS)
 
 clean:
-	$(RM) preproc preproc.exe
+	$(MSG) RM preproc$(EXE)
+	$Q$(RM) preproc preproc.exe


### PR DESCRIPTION
Fixes #131.

Heavily inspired by pokeemerald's build process.

I am no Makefile expert by any means, and whatever I used to know is a bit rusty nowadays. So there may be cleaner ways of achieving the same result. But I think this is good enough, and makes the compilation slightly more convenient. I am open to suggestions on how to improve the PR, though.

Also adds support for in-project `agbcc` installation (using its `install.sh` script), instead of requiring to add agbcc to the `$PATH`. Either of those options works now. (I find it more convenient.)